### PR TITLE
Fix nix-matrix job status

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -18,7 +18,8 @@ jobs:
         name: Generate Nix Matrix
         run: |
           set -Eeu
-          echo "matrix=$(nix eval --json '.#githubActions.matrix')" >> "$GITHUB_OUTPUT"
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   nix-build:
     needs: nix-matrix


### PR DESCRIPTION
The nix-matrix job was reported as successful when in reality the nix eval command had a non-zero exit code and failed to generate the matrix. By splitting the echo and nix eval commands up into two lines the exit code is properly detected and fails the nix-matrix job.