### PR TITLE
Fail if there are trace warnings when evaluating

### DIFF
--- a/.github/workflows/build-flake-outputs.yml
+++ b/.github/workflows/build-flake-outputs.yml
@@ -57,7 +57,12 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Get store derivation
         run: |
-          drv=$(nix path-info --derivation '.#${{ matrix.attr }}')
+          drv=$(
+            { { nix path-info --derivation '.#${{ matrix.attr }}' 1>&3; } 2>&1 |
+              tee /dev/stderr |
+              if grep 'trace: warning:' > /dev/null; then echo "warnings=true" >> "$GITHUB_ENV"; else true; fi
+            } 3>&1
+          )
           echo "drv=$drv" >> "$GITHUB_ENV"
       - name: Get output hash
         run: |
@@ -75,3 +80,6 @@ jobs:
       - name: Build output
         if: ${{ env.skip_build != 'true' }}
         run: nix build -L $drv^*
+      - name: Check if there were warnings
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: test ! "$warnings" = "true"

--- a/flake.nix
+++ b/flake.nix
@@ -91,10 +91,7 @@
             system = "x86_64-linux";
             pkgs = import inputs.nixpkgs {
               inherit system;
-              config = {
-                allowUnfree = true;
-                firefox.enableGnomeExtensions = true;
-              };
+              config = { allowUnfree = true; };
               overlays = [ inputs.self.overlays.default ];
             };
             modules = baseModules ++ [

--- a/hosts/nelvte/mpanra/nextcloud.nix
+++ b/hosts/nelvte/mpanra/nextcloud.nix
@@ -19,8 +19,8 @@
     dbhost = "/run/postgresql";
     dbname = "nextcloud";
     dbuser = "nextcloud";
-    defaultPhoneRegion = "DE";
   };
+  services.nextcloud.settings.default_phone_region = "DE";
 
   services.postgresql.ensureUsers = [
     {

--- a/hosts/nelvte/mpanra/paperless.nix
+++ b/hosts/nelvte/mpanra/paperless.nix
@@ -3,7 +3,7 @@
 {
   services.paperless.enable = true;
   services.paperless.address = "127.0.0.1";
-  services.paperless.extraConfig = {
+  services.paperless.settings = {
     PAPERLESS_URL = "https://paperless.0px.xyz";
     PAPERLESS_OCR_LANGUAGE = "deu+eng";
     # Required for some documents, see: https://docs.paperless-ngx.com/troubleshooting/#consumption-fails-with-ghostscript-pdfa-rendering-failed


### PR DESCRIPTION
Check for "trace: warning:" in stderr when evaluating a derivation and fail if it is present.