### PR TITLE
Remove dots from NixOS configuration names

### DIFF
--- a/.github/workflows/deploy-nixos-systems.yml
+++ b/.github/workflows/deploy-nixos-systems.yml
@@ -17,7 +17,7 @@ jobs:
           matrix=$(
             nix flake show --refresh --all-systems --json "." |
               jq '
-                path(.. | select(.type? == "nixos-configuration")) | last | { fqdn: . }
+                path(.. | select(.type? == "nixos-configuration")) | last | { fqdn: . | gsub("_"; ".") }
               ' |
               jq --slurp --compact-output
           )

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
           ];
         in
         {
-          "hazuno.m.0px.xyz" = inputs.nixpkgs.lib.nixosSystem rec {
+          hazuno_m_0px_xyz = inputs.nixpkgs.lib.nixosSystem rec {
             system = "x86_64-linux";
             pkgs = import inputs.nixpkgs {
               inherit system;
@@ -88,7 +88,7 @@
             ];
             specialArgs.inputs = inputs;
           };
-          "ipsmin.m.0px.xyz" = inputs.nixpkgs.lib.nixosSystem rec {
+          ipsmin_m_0px_xyz = inputs.nixpkgs.lib.nixosSystem rec {
             system = "x86_64-linux";
             pkgs = import inputs.nixpkgs {
               inherit system;
@@ -100,7 +100,7 @@
             ];
             specialArgs.inputs = inputs;
           };
-          "nelvte.m.0px.xyz" = inputs.nixpkgs.lib.nixosSystem rec {
+          nelvte_m_0px_xyz = inputs.nixpkgs.lib.nixosSystem rec {
             system = "x86_64-linux";
             pkgs = import inputs.nixpkgs {
               inherit system;


### PR DESCRIPTION
This is a workaround to get the configurations to build with garnix.